### PR TITLE
project name option 

### DIFF
--- a/braintrust/env.go
+++ b/braintrust/env.go
@@ -16,6 +16,13 @@ func WithDefaultProjectID(projectID string) Option {
 	}
 }
 
+// WithDefaultProject sets the default project name for spans created during the session.
+func WithDefaultProject(projectName string) Option {
+	return func(c *Config) {
+		c.DefaultProjectName = projectName
+	}
+}
+
 // WithAPIKey sets the API key for the Braintrust SDK.
 func WithAPIKey(apiKey string) Option {
 	return func(c *Config) {
@@ -29,6 +36,7 @@ type Config struct {
 	APIURL                string
 	AppURL                string
 	DefaultProjectID      string
+	DefaultProjectName    string
 	EnableTraceConsoleLog bool
 }
 
@@ -65,6 +73,7 @@ func GetConfig(opts ...Option) Config {
 		APIURL:                getEnvString("BRAINTRUST_API_URL", "https://api.braintrust.dev"),
 		AppURL:                getEnvString("BRAINTRUST_APP_URL", "https://www.braintrust.dev"),
 		DefaultProjectID:      getEnvString("BRAINTRUST_DEFAULT_PROJECT_ID", ""),
+		DefaultProjectName:    getEnvString("BRAINTRUST_DEFAULT_PROJECT", "default-go-project"),
 		EnableTraceConsoleLog: getEnvBool("BRAINTRUST_ENABLE_TRACE_CONSOLE_LOG", false),
 	}
 	for _, opt := range opts {

--- a/braintrust/eval/eval.go
+++ b/braintrust/eval/eval.go
@@ -437,8 +437,3 @@ func (s *typedDatasetIterator[InputType, ExpectedType]) Next() (Case[InputType, 
 		Expected: fullEvent.Expected,
 	}, nil
 }
-
-// newParent creates a new parent with the given experiment ID.
-func newParent(experimentID string) bttrace.Parent {
-	return bttrace.Parent{Type: bttrace.ParentTypeExperimentID, ID: experimentID}
-}

--- a/braintrust/eval/eval.go
+++ b/braintrust/eval/eval.go
@@ -79,7 +79,7 @@ func New[I, R any](experimentID string, cases Cases[I, R], task Task[I, R], scor
 
 	// Every span created from this eval will have the experiment ID as the parent. This _should_ be done by the SpanProcessor
 	// but just in case a user hasn't set it up, we'll do it again here just in case as it should be idempotent.
-	parent := bttrace.NewExperiment(experimentID)
+	parent := bttrace.Parent{Type: bttrace.ParentTypeExperimentID, ID: experimentID}
 	parentAttr := attr.String(bttrace.ParentOtelAttrKey, parent.String())
 	startSpanOpt := trace.WithAttributes(parentAttr)
 
@@ -436,4 +436,9 @@ func (s *typedDatasetIterator[InputType, ExpectedType]) Next() (Case[InputType, 
 		Input:    fullEvent.Input,
 		Expected: fullEvent.Expected,
 	}, nil
+}
+
+// newParent creates a new parent with the given experiment ID.
+func newParent(experimentID string) bttrace.Parent {
+	return bttrace.Parent{Type: bttrace.ParentTypeExperimentID, ID: experimentID}
 }

--- a/braintrust/eval/eval_test.go
+++ b/braintrust/eval/eval_test.go
@@ -765,7 +765,11 @@ func TestEval_BraintrustParentWithAndWithoutDefaultProject(t *testing.T) {
 			if tt.withProcessor {
 				spanProcessorOpts := []trace.SpanProcessorOption{}
 				if tt.projectID != "" {
-					spanProcessorOpts = append(spanProcessorOpts, trace.WithDefaultProjectID(tt.projectID))
+					parent := trace.Parent{
+						Type: trace.ParentTypeProjectID,
+						ID:   tt.projectID,
+					}
+					spanProcessorOpts = append(spanProcessorOpts, trace.WithDefaultParent(parent))
 				}
 				processor := trace.NewSpanProcessor(spanProcessorOpts...)
 				opts = append(opts, sdktrace.WithSpanProcessor(processor))

--- a/braintrust/trace/trace.go
+++ b/braintrust/trace/trace.go
@@ -214,6 +214,7 @@ func noopSpanProcessorOption() SpanProcessorOption {
 	return func(p *spanProcessor) {}
 }
 
+// WithDefaultParent sets the default parent for all spans that don't explicitly have one.
 func WithDefaultParent(parent Parent) SpanProcessorOption {
 	log.Debugf("Setting default parent: %s:%s", parent.Type, parent.ID)
 	return func(p *spanProcessor) {

--- a/braintrust/trace/trace.go
+++ b/braintrust/trace/trace.go
@@ -100,9 +100,13 @@ func Quickstart(opts ...braintrust.Option) (teardown func(), err error) {
 	// If we have a default project ID, set it on the span processor.
 	spanProcessorOpt := noopSpanProcessorOption()
 	if config.DefaultProjectID != "" {
-		spanProcessorOpt = WithDefaultProjectID(config.DefaultProjectID)
+		parent := Parent{Type: ParentTypeProjectID, ID: config.DefaultProjectID}
+		spanProcessorOpt = WithDefaultParent(parent)
+	} else if config.DefaultProjectName != "" {
+		parent := Parent{Type: ParentTypeProject, ID: config.DefaultProjectName}
+		spanProcessorOpt = WithDefaultParent(parent)
 	} else {
-		log.Debugf("No default project ID set. Untagged spans will be dropped")
+		log.Debugf("No default project ID or name set. Untagged spans will be dropped")
 	}
 
 	tracerOpts := []trace.TracerProviderOption{
@@ -166,44 +170,31 @@ func GetParent(ctx context.Context) (bool, Parent) {
 	return ok, parent
 }
 
+// ParentType is the type of parent.
+type ParentType string
+
+const (
+	// ParentTypeProject is the type of parent that represents a project.
+	ParentTypeProject ParentType = "project_name"
+	// ParentTypeProjectID is the type of parent that represents a project ID.
+	ParentTypeProjectID ParentType = "project_id"
+	// ParentTypeExperimentID is the type of parent that represents an experiment ID.
+	ParentTypeExperimentID ParentType = "experiment_id"
+)
+
 // Parent represents where data goes in Braintrust - a project, an experiment, etc.
-type Parent interface {
-	String() string
+type Parent struct {
+	Type ParentType
+	ID   string
 }
 
-// Project is a parent that represents a project.
-type Project struct {
-	id string
+func (p Parent) valid() bool {
+	return p.Type != "" && p.ID != ""
 }
 
-func (p Project) String() string {
-	return fmt.Sprintf("project_id:%s", p.id)
+func (p Parent) String() string {
+	return fmt.Sprintf("%s:%s", p.Type, p.ID)
 }
-
-var _ Parent = Project{}
-
-// Experiment is a parent that represents an experiment.
-type Experiment struct {
-	ID string
-}
-
-// NewProject creates a new project parent with the given ID.
-// The resulting parent will be formatted as "project_id:{id}".
-func NewProject(id string) Project {
-	return Project{id: id}
-}
-
-// NewExperiment creates a new experiment parent with the given ID.
-// The resulting parent will be formatted as "experiment_id:{id}".
-func NewExperiment(id string) Experiment {
-	return Experiment{ID: id}
-}
-
-func (e Experiment) String() string {
-	return fmt.Sprintf("experiment_id:%s", e.ID)
-}
-
-var _ Parent = Experiment{}
 
 // SpanProcessor is an OTel span processor that labels spans with their parent key.
 // It must be included in the OTel pipeline to send data to Braintrust.
@@ -212,8 +203,8 @@ type SpanProcessor interface {
 }
 
 type spanProcessor struct {
-	defaultProjectID string
-	defaultAttr      attribute.KeyValue
+	defaultParent Parent
+	defaultAttr   attribute.KeyValue
 }
 
 // SpanProcessorOption configures the span processor.
@@ -223,11 +214,10 @@ func noopSpanProcessorOption() SpanProcessorOption {
 	return func(p *spanProcessor) {}
 }
 
-// WithDefaultProjectID sets the default project ID for spans created during the session.
-func WithDefaultProjectID(projectID string) SpanProcessorOption {
-	log.Debugf("Setting default project ID: %s", projectID)
+func WithDefaultParent(parent Parent) SpanProcessorOption {
+	log.Debugf("Setting default parent: %s:%s", parent.Type, parent.ID)
 	return func(p *spanProcessor) {
-		p.defaultProjectID = projectID
+		p.defaultParent = parent
 	}
 }
 
@@ -238,8 +228,8 @@ func NewSpanProcessor(opts ...SpanProcessorOption) SpanProcessor {
 		opt(p)
 	}
 
-	if p.defaultProjectID != "" {
-		p.defaultAttr = attribute.String(ParentOtelAttrKey, NewProject(p.defaultProjectID).String())
+	if p.defaultParent.valid() {
+		p.defaultAttr = attribute.String(ParentOtelAttrKey, p.defaultParent.String())
 	}
 
 	return p
@@ -265,9 +255,9 @@ func (p *spanProcessor) OnStart(ctx context.Context, span trace.ReadWriteSpan) {
 	}
 
 	// otherwise use the default parent
-	if p.defaultProjectID != "" {
+	if p.defaultParent.valid() {
 		span.SetAttributes(p.defaultAttr)
-		log.Debugf("SpanProcessor.OnStart: setting default parent: %s", p.defaultProjectID)
+		log.Debugf("SpanProcessor.OnStart: setting default parent: %s", p.defaultParent)
 	}
 }
 

--- a/examples/anthropic-tracer/main.go
+++ b/examples/anthropic-tracer/main.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/braintrustdata/braintrust-x-go/braintrust"
-	"github.com/braintrustdata/braintrust-x-go/braintrust/api"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace/traceanthropic"
 )
@@ -217,12 +216,8 @@ func main() {
 
 	// Initialize braintrust tracing with a specific project
 	projectName := "traceanthropic-example-test"
-	project, err := api.RegisterProject(projectName)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	opt := braintrust.WithDefaultProjectID(project.ID)
+	opt := braintrust.WithDefaultProject(projectName)
 
 	teardown, err := trace.Quickstart(opt)
 	if err != nil {
@@ -238,16 +233,7 @@ func main() {
 
 	ctx := context.Background()
 
-	// Register experiment
-	experiment, err := api.RegisterExperiment("anthropic-examples", project.ID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Set the experiment as parent for tracing
-	ctx = trace.SetParent(ctx, trace.NewExperiment(experiment.ID))
-	fmt.Printf("Using project: %s (%s), experiment: %s\n", project.Name, project.ID, experiment.ID)
-
 	ctx, rootSpan := tracer.Start(ctx, "anthropic-examples")
 	defer rootSpan.End()
 

--- a/examples/traceopenai/traceopenai.go
+++ b/examples/traceopenai/traceopenai.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openai/openai-go/responses"
 
 	"github.com/braintrustdata/braintrust-x-go/braintrust"
-	"github.com/braintrustdata/braintrust-x-go/braintrust/api"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace/traceopenai"
 
@@ -281,12 +280,8 @@ func main() {
 
 	// initialize braintrust tracing with a specific project
 	projectName := "traceopenai-example-go"
-	project, err := api.RegisterProject(projectName)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	opt := braintrust.WithDefaultProjectID(project.ID)
+	opt := braintrust.WithDefaultProject(projectName)
 
 	teardown, err := trace.Quickstart(opt)
 	if err != nil {
@@ -300,16 +295,6 @@ func main() {
 	)
 
 	ctx := context.Background()
-
-	// Register experiment
-	experiment, err := api.RegisterExperiment("openai-examples", project.ID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Set the experiment as parent for tracing
-	ctx = trace.SetParent(ctx, trace.NewExperiment(experiment.ID))
-	fmt.Printf("Using project: %s (%s), experiment: %s\n", project.Name, project.ID, experiment.ID)
 
 	ctx, rootSpan := tracer.Start(ctx, "openai-examples")
 	defer rootSpan.End()

--- a/examples/traceopenai/traceopenai.go
+++ b/examples/traceopenai/traceopenai.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/responses"
 
-	"github.com/braintrustdata/braintrust-x-go/braintrust"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/trace/traceopenai"
 
@@ -278,12 +277,7 @@ func main() {
 	fmt.Println("🧠 Braintrust OpenAI Tracing Examples")
 	fmt.Println("=====================================")
 
-	// initialize braintrust tracing with a specific project
-	projectName := "traceopenai-example-go"
-
-	opt := braintrust.WithDefaultProject(projectName)
-
-	teardown, err := trace.Quickstart(opt)
+	teardown, err := trace.Quickstart()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- Adding `BRAINTRUST_DEFAULT_PROJECT` env var
-  if no project name / id is set in code or env vars, defaults to `default-go-project`