### PR TITLE
Add more friendly dataset query apis.

### DIFF
--- a/braintrust/api/project.go
+++ b/braintrust/api/project.go
@@ -66,3 +66,28 @@ func RegisterProject(name string) (*Project, error) {
 
 	return &result, nil
 }
+
+// DeleteProject deletes a project by its ID
+func DeleteProject(projectID string) error {
+	config := braintrust.GetConfig()
+
+	url := fmt.Sprintf("%s/v1/project/%s", config.APIURL, projectID)
+	httpReq, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+config.APIKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/braintrust/eval/dataset.go
+++ b/braintrust/eval/dataset.go
@@ -1,0 +1,166 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/braintrustdata/braintrust-x-go/braintrust"
+	"github.com/braintrustdata/braintrust-x-go/braintrust/api"
+)
+
+// GetDatasetByID returns Cases for the dataset with the given ID.
+func GetDatasetByID[I, R any](datasetID string) (Cases[I, R], error) {
+	if datasetID == "" {
+		return nil, fmt.Errorf("dataset ID is required")
+	}
+
+	return &datasetIterator[I, R]{
+		dataset: api.NewDataset(datasetID),
+	}, nil
+}
+
+// GetDataset returns the most recent dataset with the given project name and dataset name.
+func GetDataset[I, R any](projectName, datasetName string) (Cases[I, R], error) {
+	opts := DatasetOpts{
+		ProjectName: projectName,
+		DatasetName: datasetName,
+		Limit:       1,
+	}
+	return QueryDataset[I, R](opts)
+}
+
+// QueryDataset returns Cases for datasets matching the given options.
+func QueryDataset[I, R any](opts DatasetOpts) (Cases[I, R], error) {
+	datasets, err := queryDatasets(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query datasets: %w", err)
+	}
+
+	if len(datasets) == 0 {
+		return nil, fmt.Errorf("no datasets found matching the criteria")
+	}
+
+	// Return Cases for the first (most recent) dataset
+	return &datasetIterator[I, R]{
+		dataset: api.NewDataset(datasets[0].ID),
+	}, nil
+}
+
+// DatasetOpts provides flexible options for querying Braintrust datasets
+type DatasetOpts struct {
+	// Project identity (either/or)
+	ProjectName string // Filter by project name
+	ProjectID   string // Filter by specific project ID
+
+	// Dataset identity (either/or)
+	DatasetName string // Filter by dataset name
+	DatasetID   string // Use specific dataset ID directly
+
+	// Query modifiers
+	Version string // Specific dataset version
+	Limit   int    // Max results (default: no limit)
+}
+
+// DatasetInfo represents a Braintrust dataset.
+type DatasetInfo struct {
+	ID          string `json:"id"`
+	ProjectID   string `json:"project_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// queryDatasets queries the Braintrust API for datasets matching the options
+func queryDatasets(opts DatasetOpts) ([]DatasetInfo, error) {
+	// If dataset ID is provided directly, create a dataset entry
+	if opts.DatasetID != "" {
+		return []DatasetInfo{{
+			ID:   opts.DatasetID,
+			Name: opts.DatasetID, // Use ID as name fallback
+		}}, nil
+	}
+
+	// Otherwise query the API
+	config := braintrust.GetConfig()
+	if config.APIKey == "" {
+		return nil, fmt.Errorf("BRAINTRUST_API_KEY is required")
+	}
+
+	// Build the URL with query parameters
+	baseURL := fmt.Sprintf("%s/v1/dataset", config.APIURL)
+	params := url.Values{}
+
+	if opts.ProjectName != "" {
+		params.Add("project_name", opts.ProjectName)
+	}
+	if opts.ProjectID != "" {
+		params.Add("project_id", opts.ProjectID)
+	}
+	if opts.DatasetName != "" {
+		params.Add("dataset_name", opts.DatasetName)
+	}
+	if opts.Version != "" {
+		params.Add("version", opts.Version)
+	}
+
+	// Add limit if specified
+	if opts.Limit > 0 {
+		params.Add("limit", fmt.Sprintf("%d", opts.Limit))
+	}
+
+	fullURL := baseURL + "?" + params.Encode()
+
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+config.APIKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse the response
+	var response struct {
+		Objects []DatasetInfo `json:"objects"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return response.Objects, nil
+}
+
+type datasetIterator[InputType, ExpectedType any] struct {
+	dataset *api.Dataset
+}
+
+func (s *datasetIterator[InputType, ExpectedType]) Next() (Case[InputType, ExpectedType], error) {
+	var fullEvent struct {
+		Input    InputType    `json:"input"`
+		Expected ExpectedType `json:"expected"`
+	}
+
+	err := s.dataset.NextAs(&fullEvent)
+	if err != nil {
+		var zero Case[InputType, ExpectedType]
+		return zero, err
+	}
+
+	return Case[InputType, ExpectedType]{
+		Input:    fullEvent.Input,
+		Expected: fullEvent.Expected,
+	}, nil
+}

--- a/braintrust/eval/dataset_test.go
+++ b/braintrust/eval/dataset_test.go
@@ -1,0 +1,82 @@
+package eval
+
+import (
+	"testing"
+)
+
+func TestGetDatasetByID(t *testing.T) {
+	// Test that GetDatasetByID returns error for empty ID
+	_, err := GetDatasetByID[string, string]("")
+	if err == nil {
+		t.Error("Expected error for empty dataset ID")
+	}
+
+	// Test with valid ID (will fail API call but should return Cases)
+	cases, err := GetDatasetByID[string, string]("test-dataset-id")
+	if err != nil {
+		t.Errorf("GetDatasetByID failed: %v", err)
+	}
+	if cases == nil {
+		t.Error("Expected non-nil Cases")
+	}
+}
+
+func TestGetDataset(t *testing.T) {
+	// Test GetDataset with project and dataset names
+	_, err := GetDataset[string, string]("test-project", "test-dataset")
+	// This will fail due to API call, but function should not panic
+	if err == nil {
+		t.Log("GetDataset completed (likely failed API call, which is expected)")
+	}
+}
+
+func TestQueryDataset(t *testing.T) {
+	// Test QueryDataset with options
+	opts := DatasetOpts{
+		ProjectName: "test-project",
+		DatasetName: "test-dataset",
+		Limit:       5,
+	}
+
+	_, err := QueryDataset[string, string](opts)
+	// This will fail due to API call, but function should not panic
+	if err == nil {
+		t.Log("QueryDataset completed (likely failed API call, which is expected)")
+	}
+}
+
+func TestDatasetOpts(t *testing.T) {
+	// Test DatasetOpts struct creation
+	opts := DatasetOpts{
+		ProjectName: "test-project",
+		DatasetName: "test-dataset",
+		Limit:       10,
+	}
+
+	if opts.ProjectName != "test-project" {
+		t.Errorf("Expected ProjectName 'test-project', got %s", opts.ProjectName)
+	}
+	if opts.DatasetName != "test-dataset" {
+		t.Errorf("Expected DatasetName 'test-dataset', got %s", opts.DatasetName)
+	}
+	if opts.Limit != 10 {
+		t.Errorf("Expected Limit 10, got %d", opts.Limit)
+	}
+}
+
+func TestDatasetInfo(t *testing.T) {
+	// Test DatasetInfo struct creation
+	info := DatasetInfo{
+		ID:          "dataset-123",
+		ProjectID:   "project-456",
+		Name:        "test-dataset",
+		Description: "A test dataset",
+	}
+
+	if info.ID != "dataset-123" {
+		t.Errorf("Expected ID 'dataset-123', got %s", info.ID)
+	}
+	if info.Name != "test-dataset" {
+		t.Errorf("Expected Name 'test-dataset', got %s", info.Name)
+	}
+}

--- a/braintrust/eval/eval.go
+++ b/braintrust/eval/eval.go
@@ -407,33 +407,3 @@ func ResolveProjectExperimentID(name string, projectName string) (string, error)
 	}
 	return ResolveExperimentID(name, project.ID)
 }
-
-// QueryDataset queries a dataset from the Braintrust server and returns a Cases iterator that unmarshals
-// the dataset JSON into the given input and expected types.
-func QueryDataset[InputType, ExpectedType any](datasetID string) Cases[InputType, ExpectedType] {
-	return &typedDatasetIterator[InputType, ExpectedType]{
-		dataset: api.NewDataset(datasetID),
-	}
-}
-
-type typedDatasetIterator[InputType, ExpectedType any] struct {
-	dataset *api.Dataset
-}
-
-func (s *typedDatasetIterator[InputType, ExpectedType]) Next() (Case[InputType, ExpectedType], error) {
-	var fullEvent struct {
-		Input    InputType    `json:"input"`
-		Expected ExpectedType `json:"expected"`
-	}
-
-	err := s.dataset.NextAs(&fullEvent)
-	if err != nil {
-		var zero Case[InputType, ExpectedType]
-		return zero, err
-	}
-
-	return Case[InputType, ExpectedType]{
-		Input:    fullEvent.Input,
-		Expected: fullEvent.Expected,
-	}, nil
-}

--- a/examples/kitchen-sink/kitchen-sink.go
+++ b/examples/kitchen-sink/kitchen-sink.go
@@ -268,7 +268,10 @@ Reply with just a decimal number between 0 and 1.`, input, expected, result)
 		}),
 	}
 
-	cases := eval.QueryDataset[string, string](datasetID)
+	cases, err := eval.GetDatasetByID[string, string](datasetID)
+	if err != nil {
+		panic(fmt.Errorf("failed to get dataset: %w", err))
+	}
 
 	experimentID, err := eval.ResolveProjectExperimentID("Dataset QA", "Kitchen Sink")
 	if err != nil {

--- a/examples/struct-dataset-eval/struct-dataset-eval.go
+++ b/examples/struct-dataset-eval/struct-dataset-eval.go
@@ -121,8 +121,11 @@ func main() {
 		log.Fatalf("Failed to initialize dataset: %v", err)
 	}
 
-	// Create cases using QueryDataset with separate Input/Expected types
-	cases := eval.QueryDataset[QuestionInput, AnswerExpected](datasetID)
+	// Create cases using eval.GetDatasetByID with separate Input/Expected types
+	cases, err := eval.GetDatasetByID[QuestionInput, AnswerExpected](datasetID)
+	if err != nil {
+		log.Fatalf("❌ Failed to get dataset: %v", err)
+	}
 
 	// Define a task that processes the input and returns the expected structure
 	task := func(ctx context.Context, input QuestionInput) (AnswerExpected, error) {


### PR DESCRIPTION
  Adds `GetDatasetByID(id)`, `GetDataset(projectName, datasetName)`, and `QueryDataset(DatasetOpts)` to make it a little easier to use datasets. 

This is a backwards incompatible change `QueryDataset` used to be by ID, but I think it's a small change and worth it at this stage in the project.

this is an easy change:
` find . -name "*.go" -exec sed -i 's/eval\.QueryDataset\[/eval.GetDatasetByID[/g' {} \;`

Most people will prefer to use `eval.GetDataset(project, datasetName)` anyway 