### PR TITLE
some providers like openrouter has path prefixes so we should match on the suffix

### DIFF
--- a/braintrust/trace/traceopenai/traceopenai.go
+++ b/braintrust/trace/traceopenai/traceopenai.go
@@ -47,14 +47,15 @@ var Middleware = internal.Middleware(openaiRouter)
 
 // openaiRouter maps OpenAI API paths to their corresponding tracers.
 func openaiRouter(path string) internal.MiddlewareTracer {
-	switch path {
-	case "/v1/responses":
-		return newResponsesTracer()
-	case "/v1/chat/completions":
+	if path.HasSuffix("/v1/chat/completions") {
 		return newChatCompletionsTracer()
-	default:
-		return internal.NewNoopTracer()
 	}
+
+	if path.HasSuffix("/v1/responses") {
+		return newResponsesTracer()
+	}
+
+	return internal.NewNoopTracer()
 }
 
 // parseUsageTokens parses the usage tokens from OpenAI API responses

--- a/braintrust/trace/traceopenai/traceopenai.go
+++ b/braintrust/trace/traceopenai/traceopenai.go
@@ -47,11 +47,11 @@ var Middleware = internal.Middleware(openaiRouter)
 
 // openaiRouter maps OpenAI API paths to their corresponding tracers.
 func openaiRouter(path string) internal.MiddlewareTracer {
-	if path.HasSuffix("/v1/chat/completions") {
+	if strings.HasSuffix(path, "/v1/chat/completions") {
 		return newChatCompletionsTracer()
 	}
 
-	if path.HasSuffix("/v1/responses") {
+	if strings.HasSuffix(path, "/v1/responses") {
 		return newResponsesTracer()
 	}
 


### PR DESCRIPTION
In the middleware code, the tracer is selected based on req.URL.Path:
```go
var reqTracer MiddlewareTracer = NewNoopTracer()
if req.URL != nil {
    reqTracer = router(req.URL.Path)
}
```

If the path doesn't match a configured route in the router, it uses NewNoopTracer(), which creates but doesn't record or send any spans to Braintrust.


For OpenAI:

Base URL: https://api.openai.com/v1
Endpoint: /chat/completions (or similar)
Full path: /v1/chat/completions


For OpenRouter:

Base URL: https://openrouter.ai/api/v1
Endpoint: /chat/completions (OpenAI-compatible)
Full path: /api/v1/chat/completions