### PR TITLE
handle requests with nil bodies

### DIFF
--- a/braintrust/trace/internal/middleware.go
+++ b/braintrust/trace/internal/middleware.go
@@ -39,8 +39,8 @@ func Middleware(getMiddlewareTracer TracerRouter) func(*http.Request, NextMiddle
 			mt = getMiddlewareTracer(req.URL.Path)
 		}
 
-		// Right now we don't bother tracing requests with a nil body, becuase they have no data
-		// but that could change.
+		// Right now we don't bother tracing requests with a nil body, because they have no data.
+		// If needed, we could change that but handle the nil body sanely.
 		if mt == nil || req.Body == nil {
 			// Some endpoints aren't traced. Just pass them along.
 			return next(req)

--- a/braintrust/trace/internal/middleware.go
+++ b/braintrust/trace/internal/middleware.go
@@ -39,16 +39,14 @@ func Middleware(getMiddlewareTracer TracerRouter) func(*http.Request, NextMiddle
 			mt = getMiddlewareTracer(req.URL.Path)
 		}
 
-		var ctx context.Context
-		var span trace.Span
-		var err error
-
-		if mt == nil {
+		// Right now we don't bother tracing requests with a nil body, becuase they have no data
+		// but that could change.
+		if mt == nil || req.Body == nil {
 			// Some endpoints aren't traced. Just pass them along.
 			return next(req)
 		}
 
-		// Supported endpoint, let's set up tracing
+		// Supported endpoint, let's set up tracing.
 		var buf bytes.Buffer
 		reqBody := req.Body
 		defer func() {
@@ -60,7 +58,7 @@ func Middleware(getMiddlewareTracer TracerRouter) func(*http.Request, NextMiddle
 		// Use TeeReader - as the tracer reads from tee, it will populate buf
 		tee := io.TeeReader(reqBody, &buf)
 
-		ctx, span, err = mt.StartSpan(req.Context(), start, tee)
+		ctx, span, err := mt.StartSpan(req.Context(), start, tee)
 		if err != nil {
 			log.Warnf("Error starting span: %v", err)
 		}

--- a/braintrust/trace/internal/utils_test.go
+++ b/braintrust/trace/internal/utils_test.go
@@ -228,7 +228,6 @@ func TestMiddlewareWithNilBody(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
 
-	// Close response body to satisfy bodyclose linter
 	err = resp.Body.Close()
 	require.NoError(t, err)
 }

--- a/braintrust/trace/internal/utils_test.go
+++ b/braintrust/trace/internal/utils_test.go
@@ -200,6 +200,35 @@ func TestMiddlewareWithUnsupportedOpenAIEndpoint(t *testing.T) {
 	require.NoError(t, closeErr)
 }
 
+func TestMiddlewareWithNilBody(t *testing.T) {
+	// This test reproduces the panic that occurs when middleware encounters
+	// a traced endpoint with a nil body (like GET requests)
+
+	mockTracer := &mockTracer{}
+
+	router := func(path string) MiddlewareTracer {
+		return mockTracer
+	}
+
+	middleware := Middleware(router)
+
+	req := httptest.NewRequest("GET", "/v1/chat/completions", nil)
+	req.Body = nil
+
+	next := func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"data": []}`)),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
 func TestToInt64(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/braintrust/trace/internal/utils_test.go
+++ b/braintrust/trace/internal/utils_test.go
@@ -210,7 +210,7 @@ func TestMiddlewareWithNilBody(t *testing.T) {
 		return mockTracer
 	}
 
-	middleware := Middleware(router)
+	middleware := Middleware(router) //nolint:bodyclose // false positive - response bodies are properly closed in tests
 
 	req := httptest.NewRequest("GET", "/v1/chat/completions", nil)
 	req.Body = nil
@@ -227,6 +227,10 @@ func TestMiddlewareWithNilBody(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
+
+	// Close response body to satisfy bodyclose linter
+	err = resp.Body.Close()
+	require.NoError(t, err)
 }
 
 func TestToInt64(t *testing.T) {


### PR DESCRIPTION
this was throwing panics with requests with empty bodies like models.List()

currently we're not tracing them, but we could later.