### PR TITLE
add eval.Run which allows options, resolution, results, etc. 

### DIFF
--- a/braintrust/api/dataset.go
+++ b/braintrust/api/dataset.go
@@ -193,6 +193,43 @@ func InsertDatasetEvents(datasetID string, events []DatasetEvent) error {
 	return nil
 }
 
+// DeleteDataset deletes a dataset
+func DeleteDataset(datasetID string) error {
+	config := braintrust.GetConfig()
+
+	baseURL, err := url.Parse(config.APIURL)
+	if err != nil {
+		return fmt.Errorf("error parsing base URL: %w", err)
+	}
+
+	endpoint, err := url.Parse(fmt.Sprintf("/v1/dataset/%s", datasetID))
+	if err != nil {
+		return fmt.Errorf("error parsing endpoint: %w", err)
+	}
+
+	fullURL := baseURL.ResolveReference(endpoint)
+
+	httpReq, err := http.NewRequest("DELETE", fullURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+config.APIKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
 // Dataset handles fetching raw DatasetEvents from the Braintrust API with pagination
 type Dataset struct {
 	DatasetID string

--- a/braintrust/eval/eval_test.go
+++ b/braintrust/eval/eval_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/braintrustdata/braintrust-x-go/braintrust"
+	"github.com/braintrustdata/braintrust-x-go/braintrust/api"
 	"github.com/braintrustdata/braintrust-x-go/braintrust/internal/oteltest"
 )
 
@@ -548,6 +551,7 @@ func TestEvalWithCasesIteratorError(t *testing.T) {
 
 	// Should return the error from the Cases iterator
 	require.Error(err)
+	assert.NotNil(err)
 	assert.Contains(err.Error(), "iterator error between cases")
 
 	// Should have processed both successful cases plus one error span
@@ -741,6 +745,59 @@ func TestEval_EmptyExperimentID(t *testing.T) {
 	_ = timeRange
 }
 
+func TestEval_WithParallelism(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	_, exporter := oteltest.Setup(t)
+
+	var timerLock sync.Mutex
+	var timeRanges []oteltest.TimeRange
+
+	task := func(ctx context.Context, x int) (int, error) {
+		timer := oteltest.NewTimer()
+		time.Sleep(100 * time.Millisecond)
+		tr := timer.Tick()
+		timerLock.Lock()
+		timeRanges = append(timeRanges, tr)
+		timerLock.Unlock()
+		return x, nil
+	}
+
+	scorers := []Scorer[int, int]{
+		NewEqualsScorer[int, int](),
+	}
+
+	cases := []Case[int, int]{
+		{Input: 1, Expected: 2},
+		{Input: 2, Expected: 4},
+	}
+
+	eval := New("test-exp-456", NewCases(cases), task, scorers)
+	eval.setParallelism(2)
+	err := eval.Run(context.Background())
+	require.NoError(err)
+
+	spans := exporter.Flush()
+	assert.Equal(6, len(spans))
+
+	var tasks []oteltest.Span
+	for _, span := range spans {
+		if span.Name() == "task" {
+			tasks = append(tasks, span)
+		}
+	}
+	assert.Equal(len(cases), len(tasks))
+	assert.Equal(len(cases), len(timeRanges))
+	assert.Equal(2, len(timeRanges))
+
+	// assert both tasks start before either are finished.
+	tr1, tr2 := timeRanges[0], timeRanges[1]
+	assert.Less(tr1.Start, tr1.End)
+	assert.Less(tr1.Start, tr2.End)
+	assert.Less(tr2.Start, tr1.End)
+	assert.Less(tr2.Start, tr2.End)
+}
+
 func TestEval_BraintrustParentWithAndWithoutDefaultProject(t *testing.T) {
 
 	tests := []struct {
@@ -810,4 +867,327 @@ func (s *equalsScorer[I, R]) Run(ctx context.Context, input I, expected, result 
 
 func NewEqualsScorer[I, R comparable]() Scorer[I, R] {
 	return &equalsScorer[I, R]{}
+}
+
+func TestRun_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	task := func(ctx context.Context, x int) (int, error) {
+		return x * 2, nil
+	}
+	scorers := []Scorer[int, int]{NewEqualsScorer[int, int]()}
+	cases := NewCases([]Case[int, int]{{Input: 1, Expected: 2}})
+
+	tests := []struct {
+		name        string
+		opts        Opts[int, int]
+		expectedErr string
+	}{
+		{
+			name:        "missing task",
+			opts:        Opts[int, int]{Project: "p", Experiment: "e", Cases: cases, Scorers: scorers},
+			expectedErr: "Task is required",
+		},
+		{
+			name:        "missing scorers",
+			opts:        Opts[int, int]{Project: "p", Experiment: "e", Cases: cases, Task: task},
+			expectedErr: "at least one Scorer is required",
+		},
+		{
+			name:        "missing experiment",
+			opts:        Opts[int, int]{Project: "p", Cases: cases, Task: task, Scorers: scorers},
+			expectedErr: "Experiment is required",
+		},
+		{
+			name:        "missing cases",
+			opts:        Opts[int, int]{Project: "p", Experiment: "e", Task: task, Scorers: scorers},
+			expectedErr: "one of Cases, Dataset, or DatasetID is required",
+		},
+		{
+			name:        "multiple case sources",
+			opts:        Opts[int, int]{Project: "p", Experiment: "e", Cases: cases, Dataset: "dataset1", Task: task, Scorers: scorers},
+			expectedErr: "only one of Cases, Dataset, or DatasetID should be provided",
+		},
+		{
+			name:        "multiple case sources with DatasetID",
+			opts:        Opts[int, int]{Project: "p", Experiment: "e", Cases: cases, DatasetID: "ds-123", Task: task, Scorers: scorers},
+			expectedErr: "only one of Cases, Dataset, or DatasetID should be provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Run(ctx, tt.opts)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestEval_ParallelWithTaskErrors(t *testing.T) {
+	// Test that parallel execution properly handles multiple task errors
+	require := require.New(t)
+	assert := assert.New(t)
+	_, exporter := oteltest.Setup(t)
+
+	// Task that fails for even inputs
+	task := func(ctx context.Context, x int) (int, error) {
+		time.Sleep(50 * time.Millisecond) // Simulate work
+		if x%2 == 0 {
+			return 0, errors.New("task failed for even input")
+		}
+		return x * 2, nil
+	}
+
+	scorers := []Scorer[int, int]{
+		NewEqualsScorer[int, int](),
+	}
+
+	cases := []Case[int, int]{
+		{Input: 1, Expected: 2},
+		{Input: 2, Expected: 4},
+		{Input: 3, Expected: 6},
+		{Input: 4, Expected: 8},
+	}
+
+	eval := New("test-parallel-errors", NewCases(cases), task, scorers)
+	eval.setParallelism(3)
+	err := eval.Run(context.Background())
+
+	// Should return errors from failed tasks
+	require.Error(err)
+	assert.Contains(err.Error(), "task failed for even input")
+
+	spans := exporter.Flush()
+	// 4 cases: 2 successful (3 spans each) + 2 failed (2 spans each: task + eval)
+	// Total: 2*3 + 2*2 = 10 spans
+	assert.Equal(10, len(spans))
+}
+
+func TestEval_ParallelWithScorerErrors(t *testing.T) {
+	// Test that parallel execution properly handles multiple scorer errors
+	require := require.New(t)
+	assert := assert.New(t)
+	_, exporter := oteltest.Setup(t)
+
+	// Task that always succeeds
+	task := func(ctx context.Context, x int) (int, error) {
+		time.Sleep(50 * time.Millisecond) // Simulate work
+		return x * 2, nil
+	}
+
+	// Scorer that fails for even results
+	scorers := []Scorer[int, int]{
+		NewScorer("conditional_scorer", func(ctx context.Context, input, expected, result int, _ Metadata) (Scores, error) {
+			if result%2 == 0 && result > 2 {
+				return nil, errors.New("scorer failed for result")
+			}
+			return S(1.0), nil
+		}),
+	}
+
+	cases := []Case[int, int]{
+		{Input: 1, Expected: 2},
+		{Input: 2, Expected: 4},
+		{Input: 3, Expected: 6},
+		{Input: 4, Expected: 8},
+	}
+
+	eval := New("test-parallel-scorer-errors", NewCases(cases), task, scorers)
+	eval.setParallelism(3)
+	err := eval.Run(context.Background())
+
+	// Should return errors from failed scorers
+	require.Error(err)
+	assert.Contains(err.Error(), "scorer failed for result")
+
+	spans := exporter.Flush()
+	// All tasks succeed, but some scorers fail
+	// 4 cases * 3 spans each = 12 spans
+	assert.Equal(12, len(spans))
+}
+
+func TestEval_ParallelAllTasksFail(t *testing.T) {
+	// Test that parallel execution handles the case where all tasks fail
+	require := require.New(t)
+	assert := assert.New(t)
+	_, exporter := oteltest.Setup(t)
+
+	// Task that always fails
+	task := func(ctx context.Context, x int) (int, error) {
+		time.Sleep(50 * time.Millisecond) // Simulate work
+		return 0, errors.New("task always fails")
+	}
+
+	scorers := []Scorer[int, int]{
+		NewEqualsScorer[int, int](),
+	}
+
+	cases := []Case[int, int]{
+		{Input: 1, Expected: 2},
+		{Input: 2, Expected: 4},
+		{Input: 3, Expected: 6},
+	}
+
+	eval := New("test-parallel-all-fail", NewCases(cases), task, scorers)
+	eval.setParallelism(2)
+	err := eval.Run(context.Background())
+
+	// Should return all errors
+	require.Error(err)
+	assert.Contains(err.Error(), "task always fails")
+
+	spans := exporter.Flush()
+	// 3 cases * 2 spans each (task + eval, no scores) = 6 spans
+	// All spans should be errors since all tasks fail
+	assert.Equal(6, len(spans))
+}
+
+func TestEval_ParallelWithIteratorErrors(t *testing.T) {
+	// Test that parallel execution properly handles iterator errors mixed with successful cases
+	require := require.New(t)
+	assert := assert.New(t)
+	_, exporter := oteltest.Setup(t)
+
+	// Create a generator that returns: case1, case2, error, case3, EOF
+	generator := &errCases{
+		sequence: []errCase{
+			{c: Case[string, string]{Input: "first", Expected: "first"}},
+			{c: Case[string, string]{Input: "second", Expected: "second"}},
+			{err: errors.New("iterator error during parallel execution")},
+			{c: Case[string, string]{Input: "third", Expected: "third"}},
+		},
+		index: 0,
+	}
+
+	task := func(ctx context.Context, input string) (string, error) {
+		time.Sleep(50 * time.Millisecond) // Simulate work
+		return input, nil
+	}
+
+	scorers := []Scorer[string, string]{NewEqualsScorer[string, string]()}
+
+	eval := New("test-parallel-iterator-errors", generator, task, scorers)
+	eval.setParallelism(2)
+	err := eval.Run(context.Background())
+
+	// Should return the iterator error
+	require.Error(err)
+	assert.Contains(err.Error(), "iterator error during parallel execution")
+
+	spans := exporter.Flush()
+	// 3 successful cases * 3 spans + 1 iterator error span = 10 spans
+	assert.Equal(10, len(spans))
+}
+
+func TestRun_WithDatasetID(t *testing.T) {
+	// Integration test that uses DatasetID option in eval.Run
+	require := require.New(t)
+	assert := assert.New(t)
+
+	_, exporter := oteltest.Setup(t)
+
+	// Create a project
+	project, err := api.RegisterProject("Test Dataset Run " + time.Now().Format("20060102150405"))
+	require.NoError(err)
+
+	// Create a dataset
+	datasetInfo, err := api.CreateDataset(api.DatasetRequest{
+		ProjectID:   project.ID,
+		Name:        "test-dataset-id",
+		Description: "Test dataset for eval.Run with DatasetID",
+	})
+	require.NoError(err)
+	defer func() {
+		_ = api.DeleteDataset(datasetInfo.ID)
+	}()
+
+	// Insert test data
+	events := []api.DatasetEvent{
+		{
+			Input:    2,
+			Expected: 4,
+		},
+		{
+			Input:    5,
+			Expected: 10,
+		},
+	}
+	err = api.InsertDatasetEvents(datasetInfo.ID, events)
+	require.NoError(err)
+
+	// Run eval using DatasetID - this tests the DatasetID resolution path
+	_, err = Run(context.Background(), Opts[int, int]{
+		ProjectID:  project.ID,
+		Experiment: "test-dataset-id-experiment",
+		DatasetID:  datasetInfo.ID, // Using DatasetID directly
+		Task: func(ctx context.Context, input int) (int, error) {
+			return input * 2, nil
+		},
+		Scorers: []Scorer[int, int]{
+			NewEqualsScorer[int, int](),
+		},
+	})
+	require.NoError(err)
+
+	// Verify spans were created
+	spans := exporter.Flush()
+	assert.Equal(6, len(spans)) // 2 cases * 3 spans each
+}
+
+func TestRun_WithDatasetName(t *testing.T) {
+	// Integration test that uses Dataset name option in eval.Run
+	require := require.New(t)
+	assert := assert.New(t)
+
+	_, exporter := oteltest.Setup(t)
+
+	// Create a unique project name with timestamp
+	projectName := "Test Dataset Name Run " + time.Now().Format("20060102150405")
+	project, err := api.RegisterProject(projectName)
+	require.NoError(err)
+
+	// Create a dataset with unique name
+	datasetName := "test-dataset-name-" + time.Now().Format("20060102150405")
+	datasetInfo, err := api.CreateDataset(api.DatasetRequest{
+		ProjectID:   project.ID,
+		Name:        datasetName,
+		Description: "Test dataset for eval.Run with Dataset name",
+	})
+	require.NoError(err)
+	defer func() {
+		_ = api.DeleteDataset(datasetInfo.ID)
+	}()
+
+	// Insert test data
+	events := []api.DatasetEvent{
+		{
+			Input:    3,
+			Expected: 9,
+		},
+		{
+			Input:    4,
+			Expected: 16,
+		},
+	}
+	err = api.InsertDatasetEvents(datasetInfo.ID, events)
+	require.NoError(err)
+
+	// Run eval using Dataset name - this tests the Dataset name resolution path
+	_, err = Run(context.Background(), Opts[int, int]{
+		Project:    projectName,
+		Experiment: "test-dataset-name-experiment",
+		Dataset:    datasetName, // Using Dataset name with automatic resolution
+		Task: func(ctx context.Context, input int) (int, error) {
+			return input * input, nil
+		},
+		Scorers: []Scorer[int, int]{
+			NewEqualsScorer[int, int](),
+		},
+	})
+	require.NoError(err)
+
+	// Verify spans were created
+	spans := exporter.Flush()
+	assert.Equal(6, len(spans)) // 2 cases * 3 spans each
 }

--- a/examples/evals/evals.go
+++ b/examples/evals/evals.go
@@ -44,20 +44,17 @@ func main() {
 		return resp.OutputText(), nil
 	}
 
-	experimentID, err := eval.ResolveProjectExperimentID("go-eval-x", "go-eval-project")
-	if err != nil {
-		log.Fatalf("Failed to resolve experiment: %v", err)
-	}
-
-	eval1 := eval.New(experimentID,
-		eval.NewCases([]eval.Case[string, string]{
+	_, err = eval.Run(context.Background(), eval.Opts[string, string]{
+		Project:    "go-eval-project",
+		Experiment: "go-eval-x",
+		Cases: eval.NewCases([]eval.Case[string, string]{
 			{Input: "strawberry", Expected: "fruit"},
 			{Input: "asparagus", Expected: "vegetable"},
 			{Input: "apple", Expected: "fruit"},
 			{Input: "banana", Expected: "fruit"},
 		}),
-		getFoodType,
-		[]eval.Scorer[string, string]{
+		Task: getFoodType,
+		Scorers: []eval.Scorer[string, string]{
 			eval.NewScorer("fruit_scorer", func(_ context.Context, _, _, result string, _ eval.Metadata) (eval.Scores, error) {
 				v := 0.0
 				if result == "fruit" {
@@ -73,8 +70,7 @@ func main() {
 				return eval.S(v), nil
 			}),
 		},
-	)
-	err = eval1.Run(context.Background())
+	})
 	if err != nil {
 		log.Fatalf("Error running eval: %v", err)
 	}

--- a/examples/internal/email-evals/email-evals.go
+++ b/examples/internal/email-evals/email-evals.go
@@ -339,15 +339,14 @@ Respond with only a number 0-10.`,
 		}),
 	}
 
-	experimentID, err := eval.ResolveProjectExperimentID("Subject Line A/B Testing v1", "Email Marketing Optimization")
-	if err != nil {
-		log.Fatalf("❌ Failed to resolve experiment: %v", err)
-	}
-
-	evaluation := eval.New(experimentID, eval.NewCases(testCases), generateSubjectLine, scorers)
-
 	log.Println("🚀 Running email subject line evaluation...")
-	err = evaluation.Run(context.Background())
+	_, err = eval.Run(context.Background(), eval.Opts[EmailCampaign, SubjectLineResponse]{
+		Project:    "Email Marketing Optimization",
+		Experiment: "Subject Line A/B Testing v1",
+		Cases:      eval.NewCases(testCases),
+		Task:       generateSubjectLine,
+		Scorers:    scorers,
+	})
 	if err != nil {
 		log.Printf("⚠️  Evaluation completed with some issues: %v", err)
 	} else {

--- a/examples/scorers/scorers.go
+++ b/examples/scorers/scorers.go
@@ -23,38 +23,22 @@ func main() {
 	}
 	defer teardown()
 
-	// Simple task that just returns the input doubled
-	task := func(ctx context.Context, input int) (int, error) {
-		return input * 2, nil
-	}
-
-	// Static test cases
-	cases := []eval.Case[int, int]{
-		{Input: 5, Expected: 10},
-		{Input: 3, Expected: 6},
-		{Input: 7, Expected: 14},
-	}
-
-	// an example of a scorer that returns a single number
-	randomScorer := eval.NewScorer[int, int]("random", func(ctx context.Context, input, expected, result int, _ eval.Metadata) (eval.Scores, error) {
-		score := rand.Float64()
-		return eval.S(score), nil
-	})
-
-	// an example of a scorer that returns more than one score.
-	listScorer := eval.NewScorer[int, int]("list", func(ctx context.Context, input, expected, result int, _ eval.Metadata) (eval.Scores, error) {
-		return eval.Scores{
-			{Name: "poor", Score: 0},
-			{Name: "average", Score: 0.5},
-			{Name: "excellent", Score: 1},
-		}, nil
-	})
-
 	// Build scorers list with local scorers
 	scorers := []eval.Scorer[int, int]{
 		autoevals.NewEquals[int, int](),
-		randomScorer,
-		listScorer,
+		// an example of a scorer that returns a single number
+		eval.NewScorer[int, int]("random", func(ctx context.Context, input, expected, result int, _ eval.Metadata) (eval.Scores, error) {
+			score := rand.Float64()
+			return eval.S(score), nil
+		}),
+		// an example of a scorer that returns more than one score
+		eval.NewScorer[int, int]("list", func(ctx context.Context, input, expected, result int, _ eval.Metadata) (eval.Scores, error) {
+			return eval.Scores{
+				{Name: "poor", Score: 0},
+				{Name: "average", Score: 0.5},
+				{Name: "excellent", Score: 1},
+			}, nil
+		}),
 	}
 
 	// Try to get online scorer - add if available
@@ -67,16 +51,20 @@ func main() {
 		scorers = append(scorers, onlineScorer)
 	}
 
-	// Create evaluation
-	experimentID, err := eval.ResolveProjectExperimentID("test-go-functions", "test-go-functions")
-	if err != nil {
-		log.Fatalf("❌ Failed to resolve experiment: %v", err)
-	}
-
-	evaluation := eval.New(experimentID, eval.NewCases(cases), task, scorers)
-
 	log.Println("🚀 Running evaluation...")
-	err = evaluation.Run(context.Background())
+	_, err = eval.Run(context.Background(), eval.Opts[int, int]{
+		Project:    "test-go-functions",
+		Experiment: "test-go-functions",
+		Cases: eval.NewCases([]eval.Case[int, int]{
+			{Input: 5, Expected: 10},
+			{Input: 3, Expected: 6},
+			{Input: 7, Expected: 14},
+		}),
+		Task: func(ctx context.Context, input int) (int, error) {
+			return input * 2, nil
+		},
+		Scorers: scorers,
+	})
 	if err != nil {
 		log.Printf("⚠️ Eval completed with errors: %v", err)
 	} else {


### PR DESCRIPTION
Adds `eval.Run()` as the primary way to run evals, replacing the multi-step process of resolving IDs, creating eval instances, and running them separately. It also allows options (e.g. parallelism, quiet, whatever else), reports (e.g printing links, stats) and should be more user friendly. The parallelism option is implemented in this PR. 

  ```go
  _, err := eval.Run(ctx, eval.Opts[string, string]{
      Project:    "my-project",
      Experiment: "my-experiment",
      Cases: eval.NewCases([]eval.Case[string, string]{
          {Input: "hello", Expected: "Hello"},
      }),
      Task: func(ctx context.Context, input string) (string, error) {
          return strings.Title(input), nil
      },
      Scorers: []eval.Scorer[string, string]{
          eval.NewScorer("exact_match", ...),
      },
      Parallelism: 4, // optional
  })
```
  
  Consolidates all evaluation configuration:

  - Project resolution (optional): Project na,e or ProjectID - or falls back to default project from config
  - Experiment (required): Experiment name (resolves to ID automatically)
  - Cases (one required): Cases, Dataset, DatasetID, or DatasetOpts
  - Task (required): The function to evaluate
  - Scorers (required): List of scoring functions
  - Parallelism (optional): Number of goroutines (default: 1) (Fixes #49 )
  -  Returns evaluation results (currently a placeholder for future iterations
